### PR TITLE
✨ 온라인 구매 시 구매 링크 필수로 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,8 +341,8 @@
                     <input type="number" id="itemPrice" required placeholder="가격을 입력하세요">
                 </div>
                 <div class="form-group" id="itemLinkGroup">
-                    <label id="itemLinkLabel">구매 링크 (선택)</label>
-                    <input type="url" id="itemLink" placeholder="구매 가능한 링크를 입력하세요">
+                    <label id="itemLinkLabel">구매 링크 *</label>
+                    <input type="url" id="itemLink" required placeholder="구매 가능한 링크를 입력하세요">
                 </div>
                 <div class="modal-actions">
                     <button type="button" id="cancelBtn" class="btn secondary">취소</button>

--- a/js/student.js
+++ b/js/student.js
@@ -1513,7 +1513,7 @@ const StudentManager = {
         }
     },
 
-    // 구매 방식 변경 처리
+    // 구매 방식 변경 처리 - 수정된 구현 (온라인 구매 시 필수)
     handlePurchaseMethodChange(method) {
         try {
             const linkGroup = document.getElementById('itemLinkGroup');
@@ -1521,11 +1521,19 @@ const StudentManager = {
             const linkInput = document.getElementById('itemLink');
             
             if (method === 'offline') {
+                // 오프라인 구매: 참고 링크 (선택)
                 if (linkLabel) linkLabel.textContent = '참고 링크 (선택)';
-                if (linkInput) linkInput.placeholder = '참고할 수 있는 링크가 있다면 입력하세요';
+                if (linkInput) {
+                    linkInput.placeholder = '참고할 수 있는 링크가 있다면 입력하세요';
+                    linkInput.removeAttribute('required');
+                }
             } else {
-                if (linkLabel) linkLabel.textContent = '구매 링크 (선택)';
-                if (linkInput) linkInput.placeholder = '구매 가능한 링크를 입력하세요';
+                // 온라인 구매: 구매 링크 (필수)
+                if (linkLabel) linkLabel.textContent = '구매 링크 *';
+                if (linkInput) {
+                    linkInput.placeholder = '구매 가능한 링크를 입력하세요';
+                    linkInput.setAttribute('required', 'required');
+                }
             }
         } catch (error) {
             console.error('구매 방식 변경 처리 오류:', error);
@@ -1651,7 +1659,7 @@ const StudentManager = {
         }
     },
 
-    // 폼 데이터 수집 및 검증
+    // 폼 데이터 수집 및 검증 - 수정된 구현 (온라인 구매 시 링크 필수 검증)
     getApplicationFormData() {
         try {
             const formData = {
@@ -1679,6 +1687,13 @@ const StudentManager = {
             if (!formData.price || formData.price <= 0) {
                 alert('올바른 가격을 입력해주세요.');
                 document.getElementById('itemPrice')?.focus();
+                return null;
+            }
+
+            // 온라인 구매 시 구매 링크 필수 검증 추가
+            if (formData.purchase_type === 'online' && !formData.purchase_link) {
+                alert('온라인 구매 시 구매 링크는 필수입니다.');
+                document.getElementById('itemLink')?.focus();
                 return null;
             }
 


### PR DESCRIPTION
## 🎯 변경사항

온라인 구매 옵션 선택 시 구매 링크를 **필수 항목**으로 변경했습니다. 

관리자가 대신 구매하여 배송해주는 온라인 구매 옵션의 특성상, 구매 링크가 필수적으로 필요하다는 요구사항을 반영했습니다.

## 📝 수정된 파일

### 1. HTML (index.html)
- 구매 링크 라벨: `구매 링크 (선택)` → `구매 링크 *`
- 구매 링크 input 필드에 `required` 속성 추가
- 온라인 구매가 기본 선택이므로 초기 상태에서 구매 링크가 필수가 됨

### 2. JavaScript (js/student.js)
- **`handlePurchaseMethodChange()` 함수 개선:**
  - 온라인 구매: 라벨 "구매 링크 *", `required=true`
  - 오프라인 구매: 라벨 "참고 링크 (선택)", `required=false`
  
- **`getApplicationFormData()` 함수 검증 강화:**
  - 온라인 구매 선택 시 구매 링크가 비어있으면 필수 검증 오류 표시
  - 에러 발생 시 구매 링크 입력 필드로 자동 포커스 이동

## 🔄 동작 방식

1. **온라인 구매 선택 시 (기본값):**
   - 구매 링크 필드에 * 표시 (필수)
   - HTML5 required 속성으로 브라우저 레벨 검증
   - JavaScript로 추가 검증 및 사용자 친화적 에러 메시지

2. **오프라인 구매 선택 시:**
   - 구매 링크 필드에서 * 제거 (선택사항)
   - required 속성 제거로 선택적 입력 허용

## ✅ 테스트 시나리오

- [x] 온라인 구매 + 구매 링크 입력 → 정상 제출
- [x] 온라인 구매 + 구매 링크 미입력 → 검증 오류 및 포커스 이동
- [x] 오프라인 구매 + 구매 링크 미입력 → 정상 제출 (선택사항)
- [x] 구매 방식 전환 시 라벨 및 required 속성 올바른 변경

## 🎨 사용자 경험 개선

- 명확한 필수/선택 표시로 사용자 혼란 방지
- 실시간 폼 검증으로 제출 실패 최소화
- 에러 발생 시 해당 필드로 자동 포커스하여 빠른 수정 유도