### PR TITLE
확장된 모달 크기 구현 - 수업계획 관리 UI 개선

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -742,6 +742,15 @@ body {
     overflow-y: auto;
 }
 
+/* Expanded Modal for Lesson Plan Management */
+.modal-content.expanded {
+    width: 90vw;
+    height: 90vh;
+    max-width: 1200px;
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
 .modal-header {
     display: flex;
     justify-content: space-between;
@@ -1448,6 +1457,12 @@ body {
         width: 100%;
         margin: 0;
         min-width: auto;
+    }
+    
+    .modal-content.expanded {
+        width: 95vw;
+        height: 85vh;
+        max-width: none;
     }
     
     .modal-actions {

--- a/index.html
+++ b/index.html
@@ -624,7 +624,7 @@
 
     <!-- 수업계획 관리 모달 (관리자용) - 새로 추가 -->
     <div id="lessonPlanManagementModal" class="modal">
-        <div class="modal-content large">
+        <div class="modal-content expanded">
             <h3>수업계획 승인 관리</h3>
             <div class="lesson-plan-management-container">
                 <div class="management-header">
@@ -653,7 +653,7 @@
 
     <!-- 세부 수업계획 보기 모달 (관리자용) - 새로 추가 -->
     <div id="viewLessonPlanModal" class="modal">
-        <div class="modal-content large">
+        <div class="modal-content expanded">
             <h3>세부 수업계획 보기</h3>
             <div class="lesson-plan-detail-container">
                 <div class="lesson-plan-header-info">


### PR DESCRIPTION
## 🎯 변경사항 요약

이 PR은 수업계획 승인 관리 모달과 세부 수업계획 보기 모달의 크기를 확장하여 더 나은 사용자 경험을 제공합니다.

## 📝 주요 변경사항

### 1. CSS 개선 (main.css)
- 새로운 `.modal-content.expanded` 클래스 추가
  - 크기: 세로 90%, 가로 90%
  - 최대 너비: 1200px 제한
  - 반응형 디자인 지원

### 2. HTML 업데이트 (index.html)
- `lessonPlanManagementModal`: 수업계획 승인 관리 모달
- `viewLessonPlanModal`: 세부 수업계획 보기 모달
- 두 모달 모두 `large` → `expanded` 클래스로 변경

## 🎨 UI/UX 개선사항

- ✅ 더 넓은 화면 공간 활용으로 정보 가독성 향상
- ✅ 복잡한 수업계획 데이터를 더 편리하게 확인 가능
- ✅ 모바일 반응형 디자인 유지 (모바일에서는 95vw/85vh)
- ✅ 1200px 최대 너비 제한으로 대형 화면에서도 최적화

## 🔧 기술적 세부사항

```css
/* 새로운 확장 모달 스타일 */
.modal-content.expanded {
    width: 90vw;
    height: 90vh;
    max-width: 1200px;
    max-height: 90vh;
    overflow-y: auto;
}
```

## 📱 반응형 지원

- **데스크톱**: 90vw × 90vh (최대 1200px)
- **모바일**: 95vw × 85vh (최적화된 터치 환경)

## 🧪 테스트 가이드

1. 관리자 로그인 후 "수업계획 관리" 버튼 클릭
2. 모달이 화면의 90% 크기로 표시되는지 확인
3. "세부보기" 버튼 클릭하여 세부 모달도 확장되는지 확인
4. 다양한 화면 크기에서 반응형 작동 테스트

## 🚀 배포 안전성

- ✅ 기존 모달 스타일 유지 (하위 호환성)
- ✅ 새로운 클래스 추가로 안전한 확장
- ✅ 다른 모달들에 영향 없음
- ✅ CSS 우선순위 충돌 없음