### PR TITLE
대시보드 구매 요청 신청자수 표시 개선

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1418,7 +1418,7 @@ const AdminManager = {
         });
     },
 
-    // 통계 로드
+    // 통계 로드 - 수정된 버전 (구매 요청 신청자수/전체 학생 수 형태로 표시)
     async loadStatistics() {
         try {
             const stats = await SupabaseAPI.getStats();
@@ -1427,7 +1427,10 @@ const AdminManager = {
             const pendingCountEl = Utils.$('#pendingCount');
             const approvedCountEl = Utils.$('#approvedCount');
             
-            if (applicantCountEl) applicantCountEl.textContent = stats.applicantCount;
+            // 구매 요청 신청자수를 [신청자수] / [전체 학생 수] 형태로 표시
+            if (applicantCountEl) {
+                applicantCountEl.textContent = `${stats.applicantCount} / ${stats.totalStudents}`;
+            }
             if (pendingCountEl) pendingCountEl.textContent = stats.pendingCount;
             if (approvedCountEl) approvedCountEl.textContent = stats.approvedCount;
         } catch (error) {

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -1485,7 +1485,7 @@ const SupabaseAPI = {
         };
     },
 
-    // 일반 통계
+    // 일반 통계 - 전체 학생 수 조회 추가
     async getStats() {
         const result = await this.safeApiCall('일반 통계 조회', async () => {
             const client = await this.ensureClient();
@@ -1495,6 +1495,12 @@ const SupabaseAPI = {
                 .from('requests')
                 .select('user_id')
                 .not('user_id', 'is', null);
+            
+            // 전체 학생 수 (데이터베이스에 등록된 학생 수)
+            const totalStudentsResult = await client
+                .from('user_profiles')
+                .select('id', { count: 'exact' })
+                .eq('user_type', 'student');
             
             // 미승인 아이템
             const pendingResult = await client
@@ -1511,6 +1517,7 @@ const SupabaseAPI = {
             return {
                 data: {
                     applicants: applicantResult.data || [],
+                    totalStudents: totalStudentsResult.count || 0,
                     pendingCount: pendingResult.count || 0,
                     approvedCount: approvedResult.count || 0
                 },
@@ -1519,11 +1526,12 @@ const SupabaseAPI = {
         });
 
         if (result.success) {
-            const { applicants, pendingCount, approvedCount } = result.data;
+            const { applicants, totalStudents, pendingCount, approvedCount } = result.data;
             const uniqueApplicants = new Set(applicants.map(a => a.user_id));
             
             return {
                 applicantCount: uniqueApplicants.size,
+                totalStudents: totalStudents,
                 pendingCount,
                 approvedCount
             };
@@ -1531,6 +1539,7 @@ const SupabaseAPI = {
 
         return {
             applicantCount: 0,
+            totalStudents: 0,
             pendingCount: 0,
             approvedCount: 0
         };
@@ -1936,4 +1945,4 @@ window.addEventListener('supabaseInitError', (event) => {
 });
 
 // 초기화 완료 로그
-console.log('🚀 SupabaseAPI loaded successfully with fixed budget allocation algorithm');
+console.log('🚀 SupabaseAPI loaded successfully with updated stats including total students count');


### PR DESCRIPTION
## 📊 대시보드 구매 요청 신청자수 표시 개선

### 변경 사항
- **구매 요청 신청자수 표시 형태 변경**: `[구매 요청 신청자수] / [전체 학생 수]` 형태로 표시
- 데이터베이스에 등록된 전체 학생 수 기반으로 비율 표시

### 수정된 파일
1. **js/supabase-client.js**
   - `getStats()` 함수에 전체 학생 수 조회 기능 추가
   - `user_profiles` 테이블에서 `user_type = 'student'` 조건으로 전체 학생 수 조회

2. **js/admin.js**
   - `loadStatistics()` 함수에서 구매 요청 신청자수 표시 형태 변경
   - `applicantCount` 요소에 `${stats.applicantCount} / ${stats.totalStudents}` 형태로 표시

### 기능 개선
- ✅ 관리자가 전체 학생 대비 신청자 비율을 한눈에 파악 가능
- ✅ 데이터베이스 기반의 정확한 전체 학생 수 표시
- ✅ 기존 기능 유지하면서 추가 정보 제공

### 테스트 확인사항
- [ ] 관리자 대시보드에서 "구매 요청 신청자수" 항목이 "X / Y" 형태로 표시되는지 확인
- [ ] 전체 학생 수가 데이터베이스의 실제 학생 수와 일치하는지 확인
- [ ] 기존 통계 기능들이 정상 작동하는지 확인